### PR TITLE
fix (entityToObject) handle when id is not an ObjectID

### DIFF
--- a/packages/moleculer-db-adapter-mongoose/src/index.js
+++ b/packages/moleculer-db-adapter-mongoose/src/index.js
@@ -250,8 +250,11 @@ class MongooseStoreAdapter {
 	 */
 	entityToObject(entity) {
 		let json = entity.toJSON();
-		if (entity._id)
+		if (entity._id && entity._id.toHexString) {
 			json._id = entity._id.toHexString();
+		} else if (entity._id && entity._id.toHexString) {
+			json._id = entity._id.toString();
+		}
 		return json;
 	}
 

--- a/packages/moleculer-db-adapter-mongoose/src/index.js
+++ b/packages/moleculer-db-adapter-mongoose/src/index.js
@@ -66,8 +66,8 @@ class MongooseStoreAdapter {
 		}
 
 		const conn = mongoose.connect(uri, opts);
-		return conn.then(() => {
-			this.db = conn.connection;
+		return conn.then(result => {
+			this.db = conn.connection || result.db;
 
 			this.db.on("disconnected", function mongoDisconnected() {
 				/* istanbul ignore next */

--- a/packages/moleculer-db-adapter-mongoose/src/index.js
+++ b/packages/moleculer-db-adapter-mongoose/src/index.js
@@ -252,7 +252,7 @@ class MongooseStoreAdapter {
 		let json = entity.toJSON();
 		if (entity._id && entity._id.toHexString) {
 			json._id = entity._id.toHexString();
-		} else if (entity._id && entity._id.toHexString) {
+		} else if (entity._id && entity._id.toString) {
 			json._id = entity._id.toString();
 		}
 		return json;

--- a/packages/moleculer-db-adapter-mongoose/test/unit/index.spec.js
+++ b/packages/moleculer-db-adapter-mongoose/test/unit/index.spec.js
@@ -17,6 +17,13 @@ const doc = {
 };
 const docs = [doc];
 
+const docIdString = {
+	toJSON: jest.fn(() => ({})),
+	_id: {
+		toString: jest.fn()
+	}
+};
+
 const execCB = jest.fn(() => Promise.resolve());
 const saveCB = jest.fn(() => Promise.resolve());
 const leanCB = jest.fn(() => ({ exec: execCB }));
@@ -317,6 +324,14 @@ describe("Test MongooseStoreAdapter", () => {
 		adapter.entityToObject(doc);
 		expect(doc.toJSON).toHaveBeenCalledTimes(1);
 		expect(doc._id.toHexString).toHaveBeenCalledTimes(1);
+	});	
+
+	it("call entityToObject on doc without ObjectID", () => {
+		docIdString.toJSON.mockClear();
+		docIdString._id.toString.mockClear();
+		adapter.entityToObject(docIdString);
+		expect(docIdString.toJSON).toHaveBeenCalledTimes(1);
+		expect(docIdString._id.toString).toHaveBeenCalledTimes(1);
 	});	
 });
 


### PR DESCRIPTION
Hi,

I'm porting a Parse backend and all ids are strings :)

moleculer looks awesome btw. Thx

Cheers,
Rafae,