### PR TITLE
Added capability to add options for creating jobs

### DIFF
--- a/packages/moleculer-bull/src/index.js
+++ b/packages/moleculer-bull/src/index.js
@@ -26,10 +26,14 @@ module.exports = function createService(url, queueOpts) {
 			 *
 			 * @param {String} name
 			 * @param {any} payload
+			 * @param {any} opts
 			 * @returns {Job}
 			 */
-			createJob(name, payload) {
-				this.getQueue(name).add(payload);
+			createJob(name, payload, opts) {
+				if(opts)
+					this.getQueue(name).add(payload, opts);
+				else
+					this.getQueue(name).add(payload);
 			},
 
 			/**

--- a/packages/moleculer-bull/test/unit/index.spec.js
+++ b/packages/moleculer-bull/test/unit/index.spec.js
@@ -88,16 +88,14 @@ describe("Test BullService job with delay", () => {
 	it("should be able to add a job with delay options", () => {
 		service.getQueue = jest.fn(() => ({ add: addDelayedCB }));
 
-		service.createJob("task.scheduled", payload, { delay: 1000 });
+		service.createJob("task.scheduled", payload, { delay: 1000, a:1 });
 
 		expect(service.getQueue).toHaveBeenCalledTimes(1);
 		expect(service.getQueue).toHaveBeenCalledWith("task.scheduled");
 
-		expect(addCB).toHaveBeenCalledTimes(1);
-
 		setTimeout(() => {
-			expect(addCB).toHaveBeenCalledTimes(2);
-			expect(addCB).toHaveBeenCalledWith(payload);
+			expect(addDelayedCB).toHaveBeenCalledTimes(1);
+			expect(addDelayedCB).toHaveBeenCalledWith(payload);
 		},1001);
 	});
 

--- a/packages/moleculer-bull/test/unit/index.spec.js
+++ b/packages/moleculer-bull/test/unit/index.spec.js
@@ -80,6 +80,7 @@ describe("Test BullService created handler", () => {
 
 describe("Test BullService job with delay", () => {
 	const payload = { a: 10 };
+	const jobOpts = { delay: 1000, a:1 };
 	const broker = new ServiceBroker();
 	const service = broker.createService({
 		mixins: [BullService()]
@@ -88,14 +89,14 @@ describe("Test BullService job with delay", () => {
 	it("should be able to add a job with delay options", () => {
 		service.getQueue = jest.fn(() => ({ add: addDelayedCB }));
 
-		service.createJob("task.scheduled", payload, { delay: 1000, a:1 });
+		service.createJob("task.scheduled", payload, jobOpts);
 
 		expect(service.getQueue).toHaveBeenCalledTimes(1);
 		expect(service.getQueue).toHaveBeenCalledWith("task.scheduled");
 
 		setTimeout(() => {
 			expect(addDelayedCB).toHaveBeenCalledTimes(1);
-			expect(addDelayedCB).toHaveBeenCalledWith(payload);
+			expect(addDelayedCB).toHaveBeenCalledWith(payload, jobOpts);
 		},1001);
 	});
 


### PR DESCRIPTION
Other bull options can also be invoked now. Reference of all job options: [OptimalBits/Bull#queueadd](https://github.com/OptimalBits/bull/blob/HEAD/REFERENCE.md#queueadd)